### PR TITLE
[DSCP-418] Fix derivation

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -77,7 +77,7 @@ function getClientEnvironment(publicUrl) {
         // This should only be used as an escape hatch. Normally you would put
         // images into the `src` and `import` them in code to get their paths.
         PUBLIC_URL: publicUrl,
-        WITNESS_API_URL: process.env.WITNESS_API_URL || 'witness.faircv.dscp.serokell.review'
+        WITNESS_API_URL: process.env.WITNESS_API_URL || '//witness.faircv.dscp.serokell.review'
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,6 @@
-{ witnessUrl ? null, pkgs ? import ./pkgs.nix }:
+{ witnessUrl ? null
+, pkgs ? import ./pkgs.nix}:
 
-with pkgs;
-
-buildYarnPackage {
-  WITNESS_API_URL = witnessUrl;
-  src = constGitIgnore "validatorcv" ./. [];
+pkgs.callPackage ./release.nix {
+  inherit witnessUrl;
 }

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,5 @@
 import (fetchGit {
   url = https://github.com/serokell/serokell-closure;
-  rev = "8b9ac2eca5545fe9607364cbf4ff4f154dd6ea4e";
+  rev = "5d00f8fb8de242ed0c39db9992d0dde0f6df3c15";
+  ref = "20181218192002";
 })

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,25 @@
+{ witnessUrl ? null
+, buildYarnPackage
+, parallel
+, brotli
+, constGitIgnore
+}:
+
+buildYarnPackage {
+  WITNESS_API_URL = witnessUrl;
+  src = constGitIgnore "validatorcv" ./. [];
+
+  buildInputs = [ parallel brotli ];
+
+  postBuild = ''
+    find build/ -type f \
+      -not -name '*.jpg' \
+      -not -name '*.png' \
+      -not -name '*.webp' \
+      -not -name '*.woff' \
+      -not -name '*.woff2' | parallel brotli
+  '';
+
+  yarnBuildMore = "yarn build";
+  installPhase = "mv build $out";
+}

--- a/src/Modules/Http/index.js
+++ b/src/Modules/Http/index.js
@@ -12,35 +12,35 @@ import axios from 'axios';
 import type { AxiosInstance } from 'axios';
 import type { Error, IHttpService, ResponseType } from './Http.type';
 
-const BASE = `//${process.env.WITNESS_API_URL}/api/witness/v1`;
+const BASE = `${process.env.WITNESS_API_URL}/api/witness/v1`;
 // const BASE = '//localhost:8013/api/witness/v1';
 
 class HttpService implements IHttpService {
   httpService: typeof axios;
-  
+
   constructor(axiosService: AxiosInstance) {
     this.httpService = axiosService.create({
       baseURL: BASE
     });
   }
-  
+
   _makeBaseOptions(): any {
     return {
       headers: { 'Content-Type': 'application/json' },
       withCredentials: false
     };
   }
-  
+
   async get(url: string): Promise<ResponseType | Error> {
     const response: ResponseType = await this.httpService.get(url, this._makeBaseOptions());
     return this.dataHandler(response);
   }
-  
+
   async put(url: string, data: any): Promise<ResponseType | Error> {
     const response: ResponseType = await this.httpService.put(url, data, this._makeBaseOptions());
     return this.dataHandler(response);
   }
-  
+
   // async post(url: string, data?: any): Promise<ResponseType | Error> {
   //   const response: ResponseType = await this.httpService.post(url, data, this._makeBaseOptions());
   //   return this.dataHandler(response);
@@ -55,7 +55,7 @@ class HttpService implements IHttpService {
   //   const response: ResponseType = await this.httpService.delete(url, this._makeBaseOptions());
   //   return this.dataHandler(response);
   // }
-  
+
   dataHandler(response: ResponseType): any {
     return response.data;
   }


### PR DESCRIPTION
Problem: The previous derivation did not call `yarn build`, and just
resulted in a closure copy of the source folder. Images were not
compressed.

Solution: Call `yarn build` and use the `build` folder as closure base.
Use brotli to compress any images in the closure.